### PR TITLE
Fixed seedList type

### DIFF
--- a/nutch/nutch.py
+++ b/nutch/nutch.py
@@ -427,6 +427,9 @@ class SeedClient():
 
         seedUrl = lambda uid, url: {"id": uid, "url": url}
 
+        if not isinstance(seedList,tuple):
+            seedList = (seedList,)
+
         seedListData = {
             "id": "12345",
             "name": sid,


### PR DESCRIPTION
Fix for seedList type that resulted in `MalformedURLException` when only one url is specified as seed.
